### PR TITLE
Updating to template-haskell-2.8

### DIFF
--- a/HFlags.hs
+++ b/HFlags.hs
@@ -160,7 +160,7 @@ defineCustomFlag name' defQ argHelp readQ showQ description =
                                               moduleName
                                               (evaluate $(varE accessorName) >> return ())
                                            |]) []]]
-     flagPragmaDec <- return $ PragmaD $ InlineP accessorName $ InlineSpec False False Nothing
+     flagPragmaDec <- return $ PragmaD $ InlineP accessorName NoInline FunLike AllPhases
      flagDec <- funD accessorName [clause [] (normalB [| case True of
                                                            True -> $(appE readQ [| lookupFlag name moduleName |])
                                                            False -> $(defQ) |]) []]

--- a/hflags.cabal
+++ b/hflags.cabal
@@ -1,6 +1,6 @@
 name: hflags
-version: 0.1
-license: OtherLicense
+version: 0.1.1
+license: Apache-2.0
 license-file: COPYING
 author: Mihaly Barasz <klao@google.com>, Gergely Risko <errge@google.com>
 maintainer: Gergely Risko <errge@google.com>
@@ -68,9 +68,9 @@ library
   ghc-options: -Wall
 
   build-depends:
-      base >= 4.5 && < 5
+      base >= 4.6 && < 5
     , containers >= 0.4
-    , template-haskell >= 2.7
+    , template-haskell >= 2.8 && < 2.9
 
   exposed-modules:
     HFlags


### PR DESCRIPTION
Hi,

compiling hflags with `ghc-7.6` fails because of some changes in `TemplateHaskell`. This solved the problem for me. I hope it can help.

Fabio
