### PR TITLE
Lower Cabal-version: to >= 1.10

### DIFF
--- a/hflags.cabal
+++ b/hflags.cabal
@@ -5,7 +5,7 @@ license-file: COPYING
 author: Mihaly Barasz <klao@google.com>, Gergely Risko <gergely@risko.hu>
 maintainer: Gergely Risko <gergely@risko.hu>
 build-type: Simple
-cabal-version: >= 1.18
+cabal-version: >= 1.10
 category: Console
 stability: provisional
 homepage: http://github.com/errge/hflags


### PR DESCRIPTION
There wasn't additional functionality exposed to cabal file syntax between >=1.10 and >=1.21
See https://github.com/haskell/cabal/blob/master/Cabal/Distribution/PackageDescription/Check.hs